### PR TITLE
Add Integration Tests Failure Section

### DIFF
--- a/towerdashboard/data/base.py
+++ b/towerdashboard/data/base.py
@@ -173,31 +173,6 @@ TOWER_ANSIBLE = [
     {'tower': 'Release 3.3', 'ansible': 'stable-2.7'},
 ]
 
-SIGN_OFF_PLATFORMS = [
-    'rhel-7.7-x86_64',
-    'rhel-8.1-x86_64',
-    'OpenShift'
-]
-
-SIGN_OFF_DEPLOYMENTS = [
-    {'deploy': deploy, 'tls': tls, 'fips': fips, 'bundle': bundle}
-    for deploy, tls, fips, bundle in itertools.product(
-        ('standalone', 'cluster'),
-        ('yes', 'no'),
-        ('yes', 'no'),
-        ('yes', 'no'),
-    )
-]
-
-SIGN_OFF_COMPONENTS = [
-    'install',
-    'major_upgrade',
-    'minor_upgrade',
-    'integration',
-    'backup_restore',
-    'external_database'
-]
-
 RESULTS = [
 #     {'release': 'release_3.3.2', 'os': 'rhel-7.6-x86_64', 'ansible': 'stable-2.7', 'status': 'SUCCESS', 'job_id': 12},
 #     {'release': 'release_3.3.2', 'os': 'rhel-7.5-x86_64', 'ansible': 'stable-2.6', 'status': 'SUCCESS', 'job_id': 13},

--- a/towerdashboard/db.py
+++ b/towerdashboard/db.py
@@ -77,32 +77,6 @@ def init_db():
             _tempfile.write(
                 'INSERT INTO tower_os (tower_id, os_id) VALUES ((%s), (%s));\n' % (tower_query, os_query)
             )
-            if config['os'] in base.SIGN_OFF_PLATFORMS:
-                for item in base.SIGN_OFF_DEPLOYMENTS:
-                    for ansible in base.ANSIBLE_VERSIONS:
-                        ansible_version = ansible['name']
-                        for component in base.SIGN_OFF_COMPONENTS:
-                            if item['deploy'] == 'standalone' and config['os'] == 'OpenShift':
-                                # OpenShift is only ever tested as a cluster, so do not make jobs for this
-                                continue
-                            if item['fips'] == 'yes' and config['os'] == 'OpenShift':
-                                # OpenShift deploys do not currently support FIPS, so do not make jobs for this
-                                continue
-                            if item['bundle'] == 'yes' and config['os'] == 'OpenShift':
-                                # OpenShift deploys do not use the bundle installer, so do not make jobs for this
-                                continue
-                            if component == 'external_database' and config['os'] != 'OpenShift':
-                                # regular cluster usually uses an external db, openshift is only one we need to test this in seperate job
-                                continue
-                            job = 'component_{}_platform_{}_deploy_{}_tls_{}_fips_{}_bundle_{}_ansible_{}'.format(component, config['os'], item['deploy'], item['tls'], item['fips'], item['bundle'], ansible_version)
-                            tls_statement = '(TLS Enabled)'  if item['tls'] == 'yes' else ''
-                            fips_statement = '(FIPS Enabled)'  if item['fips'] == 'yes' else ''
-                            bundle_statement = '(Bundle installer)'  if item['bundle'] == 'yes' else ''
-                            display_name = '{} {} {} {} {} {} w/ ansible {}'.format(config['os'], item['deploy'], component.replace('_', ' '), tls_statement, fips_statement, bundle_statement, ansible_version)
-                            display_name = display_name.title()
-                            _tempfile.write(
-                                'INSERT INTO sign_off_jobs (tower_id, job, display_name, component, platform, deploy, tls, fips, bundle, ansible) VALUES ((%s), "%s", "%s", "%s", "%s", "%s", "%s", "%s", "%s", "%s");\n' % (tower_query, job, display_name, component, config['os'], item['deploy'], item['tls'], item['fips'], item['bundle'], ansible_version)
-                            )
 
         for config in base.TOWER_ANSIBLE:
             tower_query = 'SELECT id FROM tower_versions WHERE version = "%s"' % config['tower']

--- a/towerdashboard/jenkins/base.py
+++ b/towerdashboard/jenkins/base.py
@@ -165,6 +165,7 @@ def sign_off_jobs():
     else:
         payload = flask.request.json
         required_keys = ['tower', 'component', 'deploy', 'platform', 'tls', 'fips', 'bundle', 'ansible', 'url', 'status']
+
         check_payload(payload, required_keys)
         tower_query = form_tower_query(payload['tower'])
         condition = 'tower_id = (%s) AND component = "%s" AND deploy = "%s" AND platform = "%s" AND' \

--- a/towerdashboard/schema.sql
+++ b/towerdashboard/schema.sql
@@ -68,3 +68,19 @@ CREATE TABLE sign_off_jobs (
   ansible TEXT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE integration_tests (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  test_name TEXT NOT NULL,
+  tower_id INTEGER NOT NULL,
+  deploy TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  bundle TEXT NOT NULL,
+  tls TEXT NOT NULL,
+  fips TEXT NOT NULL,
+  status TEXT,
+  url TEXT,
+  ansible TEXT NOT NULL,
+  created_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  failing_since DATE
+);

--- a/towerdashboard/static/script.js
+++ b/towerdashboard/static/script.js
@@ -1,0 +1,97 @@
+// Code goes here
+
+$(document).ready(function(){
+    
+    $(".grid thead td").click(function(){
+      showFilterOption(this);
+    });
+    
+});
+
+var arrayMap = {};
+
+function showFilterOption(tdObject){
+  var filterGrid = $(tdObject).find(".filter");
+  
+  if (filterGrid.is(":visible")){
+    filterGrid.hide();
+    return;
+  }
+  
+  $(".filter").hide();
+  
+  var index = 0;
+  filterGrid.empty();
+  var allSelected = true;
+  filterGrid.append('<div><input id="all" type="checkbox" checked>Select All</div>');
+  
+  var $rows = $(tdObject).parents("table").find("tbody tr");
+  var unique_rows = []
+  
+  $rows.each(function(ind, ele){
+    var currentTd = $(ele).children()[$(tdObject).attr("index")];
+    if (!unique_rows.includes(currentTd.id)){
+        var div = document.createElement("div");
+        div.classList.add("grid-item")
+        var str = $(ele).is(":visible") ? 'checked' : '';
+        if ($(ele).is(":hidden")){
+          allSelected = false;
+        }
+        div.innerHTML = '<input type="checkbox" '+str+' >'+currentTd.innerHTML;
+        filterGrid.append(div);
+        arrayMap[index] = ele;
+        unique_rows[index] = currentTd.id;
+        index++;
+    }
+  });
+  
+  if (!allSelected){
+    filterGrid.find("#all").removeAttr("checked");
+  }
+  
+  filterGrid.append('<div><input id="close" type="button" value="Close"/><input id="ok" type="button" value="Ok"/></div>');
+  filterGrid.show();
+  
+  var $closeBtn = filterGrid.find("#close");
+  var $okBtn = filterGrid.find("#ok");
+  var $checkElems = filterGrid.find("input[type='checkbox']");
+  var $gridItems = filterGrid.find(".grid-item");
+  var $all = filterGrid.find("#all");
+  
+  $closeBtn.click(function(){
+    filterGrid.hide();
+    return false;
+  });
+  
+  $okBtn.click(function(){
+    filterGrid.find(".grid-item").each(function(ind,ele){
+      if ($(ele).find("input").is(":checked")){
+        $(arrayMap[ind]).show();
+      }else{
+        $(arrayMap[ind]).hide();
+      }
+    });
+    filterGrid.hide();
+    return false;
+  });
+  
+  $checkElems.click(function(event){
+    event.stopPropagation();
+  });
+  
+  $gridItems.click(function(event){
+    var chk = $(this).find("input[type='checkbox']");
+    $(chk).prop("checked",!$(chk).is(":checked"));
+  });
+  
+  $all.change(function(){
+    var chked = $(this).is(":checked");
+    filterGrid.find(".grid-item [type='checkbox']").prop("checked",chked);
+  })
+  
+  filterGrid.click(function(event){
+    event.stopPropagation();
+  });
+  
+  return filterGrid;
+}

--- a/towerdashboard/static/script.js
+++ b/towerdashboard/static/script.js
@@ -2,96 +2,109 @@
 
 $(document).ready(function(){
     
-    $(".grid thead td").click(function(){
-      showFilterOption(this);
-    });
-    
+  $(".grid thead td").click(function(){
+    showFilterOption(this);
+  });
+  
 });
 
 var arrayMap = {};
 
 function showFilterOption(tdObject){
-  var filterGrid = $(tdObject).find(".filter");
-  
-  if (filterGrid.is(":visible")){
-    filterGrid.hide();
-    return;
+var filterGrid = $(tdObject).find(".filter");
+
+if (filterGrid.is(":visible")){
+  filterGrid.hide();
+  return;
+}
+
+$(".filter").hide();
+
+var index = 0;
+filterGrid.empty();
+var allSelected = true;
+filterGrid.append('<div><input id="all" type="checkbox" checked>Select All</div>');
+
+var $rows = $(tdObject).parents("table").find("tbody tr");
+
+var unique_rows=[]
+$rows.each(function(ind, ele){
+  var currentTd = $(ele).children()[$(tdObject).attr("index")];
+  if (!unique_rows.includes(currentTd.id)){
+      var div = document.createElement("div");
+      div.classList.add("grid-item")
+      var str = $(ele).is(":visible") ? 'checked' : '';
+      if ($(ele).is(":hidden")){
+        allSelected = false;
+      }
+      div.innerHTML = '<input type="checkbox" '+str+' >'+currentTd.innerHTML;
+      filterGrid.append(div);
+      arrayMap[index] = ele;
+      unique_rows[index] = currentTd.id;
+      index++;
   }
-  
-  $(".filter").hide();
-  
-  var index = 0;
-  filterGrid.empty();
-  var allSelected = true;
-  filterGrid.append('<div><input id="all" type="checkbox" checked>Select All</div>');
-  
-  var $rows = $(tdObject).parents("table").find("tbody tr");
-  var unique_rows = []
-  
-  $rows.each(function(ind, ele){
-    var currentTd = $(ele).children()[$(tdObject).attr("index")];
-    if (!unique_rows.includes(currentTd.id)){
-        var div = document.createElement("div");
-        div.classList.add("grid-item")
-        var str = $(ele).is(":visible") ? 'checked' : '';
-        if ($(ele).is(":hidden")){
-          allSelected = false;
+});
+
+if (!allSelected){
+  filterGrid.find("#all").removeAttr("checked");
+}
+
+filterGrid.append('<div><input id="close" type="button" value="Close"/><input id="ok" type="button" value="Ok"/></div>');
+filterGrid.show();
+
+var $closeBtn = filterGrid.find("#close");
+var $okBtn = filterGrid.find("#ok");
+var $checkElems = filterGrid.find("input[type='checkbox']");
+var $gridItems = filterGrid.find(".grid-item");
+var $all = filterGrid.find("#all");
+
+$closeBtn.click(function(){
+  filterGrid.hide();
+  return false;
+});
+
+$okBtn.click(function(){
+  filterGrid.find(".grid-item").each(function(ind,ele){  
+    var rows = $(tdObject).parents("table").find("tbody tr");  
+    if ($(ele).find("input").is(":checked")){
+      //$(arrayMap[ind]).show();
+      for(var i = 0; i< rows.length; i++){
+        columns = $(rows[i]).find('td');
+        if($(rows[i]).text().includes($(ele).text())){
+        $(rows[i]).show();
         }
-        div.innerHTML = '<input type="checkbox" '+str+' >'+currentTd.innerHTML;
-        filterGrid.append(div);
-        arrayMap[index] = ele;
-        unique_rows[index] = currentTd.id;
-        index++;
+      }
+    }else{
+      for(var i = 0; i< rows.length; i++){
+        columns = $(rows[i]).find('td');
+        if($(rows[i]).text().includes($(ele).text())){
+        $(rows[i]).hide();
+        }
+      }
+      //$(arrayMap[ind]).hide();
     }
   });
-  
-  if (!allSelected){
-    filterGrid.find("#all").removeAttr("checked");
-  }
-  
-  filterGrid.append('<div><input id="close" type="button" value="Close"/><input id="ok" type="button" value="Ok"/></div>');
-  filterGrid.show();
-  
-  var $closeBtn = filterGrid.find("#close");
-  var $okBtn = filterGrid.find("#ok");
-  var $checkElems = filterGrid.find("input[type='checkbox']");
-  var $gridItems = filterGrid.find(".grid-item");
-  var $all = filterGrid.find("#all");
-  
-  $closeBtn.click(function(){
-    filterGrid.hide();
-    return false;
-  });
-  
-  $okBtn.click(function(){
-    filterGrid.find(".grid-item").each(function(ind,ele){
-      if ($(ele).find("input").is(":checked")){
-        $(arrayMap[ind]).show();
-      }else{
-        $(arrayMap[ind]).hide();
-      }
-    });
-    filterGrid.hide();
-    return false;
-  });
-  
-  $checkElems.click(function(event){
-    event.stopPropagation();
-  });
-  
-  $gridItems.click(function(event){
-    var chk = $(this).find("input[type='checkbox']");
-    $(chk).prop("checked",!$(chk).is(":checked"));
-  });
-  
-  $all.change(function(){
-    var chked = $(this).is(":checked");
-    filterGrid.find(".grid-item [type='checkbox']").prop("checked",chked);
-  })
-  
-  filterGrid.click(function(event){
-    event.stopPropagation();
-  });
-  
-  return filterGrid;
+  filterGrid.hide();
+  return false;
+});
+
+$checkElems.click(function(event){
+  event.stopPropagation();
+});
+
+$gridItems.click(function(event){
+  var chk = $(this).find("input[type='checkbox']");
+  $(chk).prop("checked",!$(chk).is(":checked"));
+});
+
+$all.change(function(){
+  var chked = $(this).is(":checked");
+  filterGrid.find(".grid-item [type='checkbox']").prop("checked",chked);
+})
+
+filterGrid.click(function(event){
+  event.stopPropagation();
+});
+
+return filterGrid;
 }

--- a/towerdashboard/static/style.css
+++ b/towerdashboard/static/style.css
@@ -1,0 +1,14 @@
+table thead tr td{
+  background-color : gray;
+  min-width : 100px;
+  position: relative;
+}
+
+.filter{
+  position:absolute;
+  border: solid 1px;
+  top : 20px;
+  background-color : white;
+  right:0;
+  display:none;
+}

--- a/towerdashboard/static/style.css
+++ b/towerdashboard/static/style.css
@@ -1,3 +1,5 @@
+/* Styles go here */
+
 table thead tr td{
   background-color : gray;
   min-width : 100px;
@@ -9,6 +11,7 @@ table thead tr td{
   border: solid 1px;
   top : 20px;
   background-color : white;
+  width:max-content;
   right:0;
   display:none;
 }

--- a/towerdashboard/templates/jenkins/integration_test_results.html
+++ b/towerdashboard/templates/jenkins/integration_test_results.html
@@ -1,0 +1,113 @@
+{% extends 'base.html' %}
+
+{% block content %}
+    <script data-require="jquery@2.0.3" data-semver="2.0.3" src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
+<br/>
+<ul class="nav nav-tabs">
+{% for version in versions %}
+  <li class="nav-item">
+	  <a class="nav-link {% if loop.index == 1 %}active{% endif %}" data-toggle="tab" href="#release{{ version.id }}">Release {{ version.next_release }} {% if loop.index == 1 %}(devel){% endif %}</a>
+  </li>
+{% endfor %}
+</ul>
+
+
+<div class="tab-content">
+{% for version in versions %}
+  <div class="tab-pane {% if loop.index == 1 %}active{% endif %}" id="release{{ version.id }}">
+
+    <br/><br/>
+    <h4>Integration Results</h4>
+    <hr/>
+
+    <img src="{{ url_for('static', filename='green.png') }}"></img><img src="{{ url_for('static', filename='red.png') }}"></img><img src="{{ url_for('static', filename='yellow.png') }}"></img> Fresh results (Less than 2 days)
+    <img style="opacity: 0.5;" src="{{ url_for('static', filename='green.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='red.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='yellow.png') }}"></img> Non fresh results (older than 2 days)
+    <img src="{{ url_for('static', filename='grey.png') }}"></img> Never run yet
+
+
+    <table id="table1" class="table table-bordered grid">
+        <thead align="center">
+          <tr>
+            <td index=0>Test
+              <div class="filter"></div>
+            </td>
+            <td index=1>Deploy
+              <div class="filter"></div>
+            </td>
+            <td index=2>OS
+              <div class="filter"></div>
+            </td>
+            <td index=3>Bundle
+              <div class="filter"></div>
+            </td>
+            <td index=4>TLS
+              <div class="filter"></div>
+            </td>
+             <td index=5>FIPS
+              <div class="filter"></div>
+            </td>
+            <td index=6>Ansible
+              <div class="filter"></div>
+            </td>
+            <td index=7>Job URL
+            </td>
+            <td index=8>Failed On
+            </td>
+            <td index=8>Failing since
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+                {% for test in integration_test_results %}
+                  {% if test.tower_id == version.id %}
+                    <tr>
+                      <td align="left" id={{ test.test_name }} >{{ test.test_name }}</td>
+                      <td align="left" id={{ test.deploy }}>{{ test.deploy }}</td>
+                      <td align="left" id={{ test.platform }}>{{ test.platform }}</td>
+                      <td align="left" id={{ test.bundle }}>{{ test.bundle }}</td>
+                      <td align="left" id={{ test.tls }}>{{ test.tls }}</td>
+                      <td align="left" id={{ test.fips }}>{{ test.fips }}</td>
+                      <td align="left" id={{ test.ansible }}>{{ test.ansible }}</td>
+
+                      {% if test.status == 'SUCCESS' %}
+                        {% if test.freshness < 2 %}
+                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='green.png') }}"></img></a></td>
+                        {% else %}
+                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='green.png') }}"></img></a></td>
+                        {% endif %}
+                      {% elif test.status == 'FAILURE' %}
+                        {% if test.freshness < 2 %}
+                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='red.png') }}"></img></a></td>
+                        {% else %}
+                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='red.png') }}"></img></a></td>
+                        {% endif %}
+                      {% elif test.status == 'UNSTABLE' %}
+                        {% if test.freshness < 2 %}
+                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
+                        {% else %}
+                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
+                        {% endif %}
+                      {% else %}
+                        <td align="center">
+                        {% if test.url %}
+                            <a href="{{ test.url }}"><img src="{{ url_for('static', filename='grey.png') }}"></img></a>
+                        {% else %}
+                            <img src="{{ url_for('static', filename='grey.png') }}"></img>
+                        {% endif %}
+                        </td>
+                      {% endif %}
+                      <td align="left" id={{ test.created_on }}>{{ test.created_at }}</td>
+                      <td align="left" id={{ test.failing_since }}>{{ test.failing_since }}</td>
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+            </tbody>
+    </table>
+  </div>
+{% endfor %}
+</div>
+
+{% endblock %}
+

--- a/towerdashboard/templates/jenkins/integration_test_results.html
+++ b/towerdashboard/templates/jenkins/integration_test_results.html
@@ -1,9 +1,8 @@
 {% extends 'base.html' %}
 
 {% block content %}
-    <script data-require="jquery@2.0.3" data-semver="2.0.3" src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 <br/>
 <ul class="nav nav-tabs">
 {% for version in versions %}
@@ -46,16 +45,19 @@
               <div class="filter"></div>
             </td>
              <td index=5>FIPS
-              <div class="filter"></div>
+               <div class="filter"></div>
             </td>
             <td index=6>Ansible
               <div class="filter"></div>
             </td>
             <td index=7>Job URL
+              <div class="filter"></div>
             </td>
             <td index=8>Failed On
+              <div class="filter"></div>
             </td>
-            <td index=8>Failing since
+            <td index=9>Failing since
+              <div class="filter"></div>
             </td>
           </tr>
         </thead>
@@ -73,21 +75,21 @@
 
                       {% if test.status == 'SUCCESS' %}
                         {% if test.freshness < 2 %}
-                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='green.png') }}"></img></a></td>
+                        <td align="center" id='green'><a href="{{ test.url }}"><img src="{{ url_for('static', filename='green.png') }}"></img></a></td>
                         {% else %}
-                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='green.png') }}"></img></a></td>
+                        <td align="center" id='green'><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='green.png') }}"></img></a></td>
                         {% endif %}
                       {% elif test.status == 'FAILURE' %}
                         {% if test.freshness < 2 %}
-                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='red.png') }}"></img></a></td>
+                        <td align="center" id='red'><a href="{{ test.url }}"><img src="{{ url_for('static', filename='red.png') }}"></img></a></td>
                         {% else %}
-                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='red.png') }}"></img></a></td>
+                        <td align="center" id='red'><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='red.png') }}"></img></a></td>
                         {% endif %}
                       {% elif test.status == 'UNSTABLE' %}
                         {% if test.freshness < 2 %}
-                        <td align="center"><a href="{{ test.url }}"><img src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
+                        <td align="center" id='yellow'><a href="{{ test.url }}"><img src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
                         {% else %}
-                        <td align="center"><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
+                        <td align="center" id='yellow'><a href="{{ test.url }}"><img style="opacity: 0.5" src="{{ url_for('static', filename='yellow.png') }}"></img></a></td>
                         {% endif %}
                       {% else %}
                         <td align="center">

--- a/towerdashboard/templates/jenkins/releases.html
+++ b/towerdashboard/templates/jenkins/releases.html
@@ -260,12 +260,14 @@
     <div class="card-header" id="headingSignOff">
       <h5 class="mb-0">
         <h4>All Sign Off Jobs for Release</h4>
-        <button class="btn btn-link" data-toggle="collapse" data-target="#collapseSignOff" aria-expanded="true" aria-controls="collapseSignOff">
-			  click to hide or expand
-        </button>
+        
       </h5>
     </div>
 
+    {% if sign_off_jobs %}
+    <button class="btn btn-link" data-toggle="collapse" data-target="#collapseSignOff" aria-expanded="true" aria-controls="collapseSignOff">
+      click to hide or expand
+    </button>
     <div id="collapseSignOff" class="collapse show" aria-labelledby="headingSignOff" data-parent="#accordionSignOff">
       <div class="card-body">
         <table class="table table-bordered">
@@ -312,6 +314,9 @@
         </table>
       </div>
     </div>
+    {% else %}
+    <h5>There are no sign off jobs to display.</h5>
+    {% endif %}    
   </div>
 </div>
 


### PR DESCRIPTION
Issue: https://github.com/ansible/tower-dashboard/issues/27

This PR contains the initial setup and a basic table displaying test failures across all jobs.
The table also contains filtering options as follows:
<img width="1309" alt="Screen Shot 2020-02-11 at 10 43 09 AM" src="https://user-images.githubusercontent.com/11617351/74252257-65477a80-4cbb-11ea-8556-d976e482b7bc.png">

Checklist:
- [x] Create table and endpoint to GET and POST to table "integration_tests" in database: `/jenkins/integration_tests`
- [x] Basic UI endpoint: `/jenkins/integration_test_results`
- [x] Tweek integration.groovy file to send the test results (results.xml) to the towerdashboard endpoint
- [ ] TODO: get feedback from some UI developer to make the code more efficient/user friendly