### PR TITLE
docker env python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t ansible/dashboard -f tools/Dockerfile .
+
+run:
+	CURRENT_UID=$(shell id -u) docker-compose -f tools/docker-compose.yml up --no-recreate

--- a/README.md
+++ b/README.md
@@ -118,49 +118,14 @@ To be able to update a production environment, few steps are required:
 
 To be able to set up a dev environment, few steps are required.
 
-  1. Ensure `pip` and `virtualenv` are installed
+```
+make build
+cp settings.sample.py settings.py
+make run
 
-  ```bash
-  #> yum -y install python-pip python-virtualenvironment
-  ```
-
-  2. Create yourself a virtual environment
-
-  ``` bash
-  #> virtualenv /path/to/towerdashboard/venv
-  #> source /path/to/towerdashboard/venv/bin/activate
-  ```
-
-  3. Clone the repository
-
-  ``` bash
-  #> git clone https://github.com/ansible/tower-dashboard
-  ```
-
-  4. Install the dependencies
-
-  ``` bash
-  #> cd tower-dashboard
-  #> pip install -r requirements.txt
-  ```
-
-  5. Copy and edit the settings.sample.py file
-
-  ``` bash
-  #> cp settings.sample.py /tmp/settings.py
-  #> vim /tmp/settings.py
-  ```
-
-  5. Rock'n'Roll
-
-  ``` bash
-  #> FLASK_APP=/path/to/towerdashboard/app.py FLASK_DEBUG=1 TOWERDASHBOARD_SETTINGS=/tmp/settings.py flask run
-  ```
-
-  6. Initialize the DB
-  ```
-  #> curl http://127.0.0.1:5000/init-db
-  ```
+# Initialize the DB
+curl http://127.0.0.1:5000/init-db
+```
 
 tower-dashboard should be running on your local loop on port 5000 (`http://127.0.0.1:5000`)
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:latest
+
+RUN dnf -y install python3
+RUN pip3 install "virtualenv<20"
+
+RUN mkdir /tmp/requirements/
+ADD requirements.txt \
+    test-requirements.txt \
+    /tmp/requirements/
+
+RUN cat /tmp/requirements/* > /tmp/requirements/requirements_all.txt
+
+RUN virtualenv /venv
+RUN /venv/bin/pip install -r /tmp/requirements/requirements_all.txt
+
+CMD ["bash"]

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+version: "3"
+services:
+  dashboard:
+    user: ${CURRENT_UID}
+    image: ansible/dashboard:latest
+    container_name: dashboard
+    hostname: dashboard
+    environment:
+      CURRENT_UID:
+      FLASK_ENV: development
+      FLASK_APP: /dashboard_devel/towerdashboard/app.py
+      TOWERDASHBOARD_SETTINGS: /dashboard_devel/settings.py
+      PYTHONUNBUFFERED: 0
+    ports:
+      - "5000:5000"
+    working_dir: "/dashboard_devel"
+    volumes:
+      - "../:/dashboard_devel"
+    command: ["/venv/bin/flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
related to https://github.com/ansible/tower-dashboard/issues/59

I poked at a few endpoints with this python3 env and no tracebacks. There is still some work to do in `setup.py` and the rpm builder for full python3 support.