### PR TITLE
Table filter fixes

### DIFF
--- a/towerdashboard/jenkins/base.py
+++ b/towerdashboard/jenkins/base.py
@@ -365,8 +365,8 @@ def integration_test_results():
                 status=400,
                 content_type='application/json'
             )
-    fetch_querry = 'SELECT * FROM integration_tests'
-    integration_test_results = db_access.execute(fetch_querry).fetchall()
+    fetch_query = 'SELECT * FROM integration_tests'
+    integration_test_results = db_access.execute(fetch_query).fetchall()
     integration_test_results = db.format_fetchall(integration_test_results)
     integration_test_results = set_freshness(integration_test_results, 'created_at', duration = 1)
     integration_test_results = sorted(integration_test_results, key = lambda i: i['created_at'],reverse=True) 

--- a/towerdashboard/jenkins/base.py
+++ b/towerdashboard/jenkins/base.py
@@ -359,6 +359,7 @@ def integration_test_results():
     integration_test_results = db_access.execute(fetch_querry).fetchall()
     integration_test_results = db.format_fetchall(integration_test_results)
     integration_test_results = set_freshness(integration_test_results, 'created_at', duration = 1)
+    integration_test_results = sorted(integration_test_results, key = lambda i: i['created_at'],reverse=True) 
 
 
     return flask.render_template(

--- a/towerdashboard/static/script.js
+++ b/towerdashboard/static/script.js
@@ -64,24 +64,23 @@ $closeBtn.click(function(){
 });
 
 $okBtn.click(function(){
+  var rows = $(tdObject).parents("table").find("tbody tr"); 
   filterGrid.find(".grid-item").each(function(ind,ele){  
     var rows = $(tdObject).parents("table").find("tbody tr");  
     if ($(ele).find("input").is(":checked")){
-      //$(arrayMap[ind]).show();
       for(var i = 0; i< rows.length; i++){
-        columns = $(rows[i]).find('td');
-        if($(rows[i]).text().includes($(ele).text())){
+        if($(rows[i]).text().includes($(ele).text()) && !$(rows[i]).is(":hidden")){
         $(rows[i]).show();
+        $(rows[i]).hidden = false
         }
       }
     }else{
       for(var i = 0; i< rows.length; i++){
-        columns = $(rows[i]).find('td');
         if($(rows[i]).text().includes($(ele).text())){
         $(rows[i]).hide();
+        $(rows[i]).hidden = true
         }
       }
-      //$(arrayMap[ind]).hide();
     }
   });
   filterGrid.hide();

--- a/towerdashboard/static/style.css
+++ b/towerdashboard/static/style.css
@@ -11,8 +11,10 @@ table thead tr td{
   border: solid 1px;
   padding: 8px;
   top : 80px;
-  height: 300px;
+  max-height: 300px;
   overflow: scroll;
+  right:0;
+  width:"max-content";
   background-color : white;
   text-align: left;
   display:none;

--- a/towerdashboard/static/style.css
+++ b/towerdashboard/static/style.css
@@ -9,9 +9,11 @@ table thead tr td{
 .filter{
   position:absolute;
   border: solid 1px;
-  top : 20px;
+  padding: 8px;
+  top : 80px;
+  height: 300px;
+  overflow: scroll;
   background-color : white;
-  width:max-content;
-  right:0;
+  text-align: left;
   display:none;
 }

--- a/towerdashboard/templates/jenkins/integration_test_results.html
+++ b/towerdashboard/templates/jenkins/integration_test_results.html
@@ -23,8 +23,8 @@
     <br/>
     <a href="{{ url_for(endpoint='jenkins.integration_test_results', failed_on='today') }}">Click here to see today's results </a>
     <br/>
-    <img src="{{ url_for('static', filename='yellow.png') }}"></img> Fresh results (Same day)
-    <img style="opacity: 0.5;" src="{{ url_for('static', filename='yellow.png') }}"></img> Non fresh results (Previous test failures)
+    <img src="{{ url_for('static', filename='green.png') }}"></img><img src="{{ url_for('static', filename='red.png') }}"></img><img src="{{ url_for('static', filename='yellow.png') }}"></img> Fresh results (Same day)
+    <img style="opacity: 0.5;" src="{{ url_for('static', filename='green.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='red.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='yellow.png') }}"></img> Non fresh results (Previous test failures)
 
 
     <table id="table1" class="table table-bordered grid">
@@ -100,7 +100,7 @@
                         {% endif %}
                         </td>
                       {% endif %}
-                      <td align="left" id={{ test.created_on }}>{{ test.created_at }}</td>
+                      <td align="left" id={{ test.created_at }}>{{ test.created_at }}</td>
                       <td align="left" id={{ test.failing_since }}>{{ test.failing_since }}</td>
                     </tr>
                   {% endif %}

--- a/towerdashboard/templates/jenkins/integration_test_results.html
+++ b/towerdashboard/templates/jenkins/integration_test_results.html
@@ -20,9 +20,11 @@
     <br/><br/>
     <h4>Integration Results</h4>
     <hr/>
-
-    <img src="{{ url_for('static', filename='green.png') }}"></img><img src="{{ url_for('static', filename='red.png') }}"></img><img src="{{ url_for('static', filename='yellow.png') }}"></img> Fresh results (Same day)
-    <img style="opacity: 0.5;" src="{{ url_for('static', filename='green.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='red.png') }}"></img><img style="opacity: 0.5;" src="{{ url_for('static', filename='yellow.png') }}"></img> Non fresh results (Previous test failures)
+    <br/>
+    <a href="{{ url_for(endpoint='jenkins.integration_test_results', failed_on='today') }}">Click here to see today's results </a>
+    <br/>
+    <img src="{{ url_for('static', filename='yellow.png') }}"></img> Fresh results (Same day)
+    <img style="opacity: 0.5;" src="{{ url_for('static', filename='yellow.png') }}"></img> Non fresh results (Previous test failures)
 
 
     <table id="table1" class="table table-bordered grid">


### PR DESCRIPTION
Issue: https://github.com/ansible/tower-dashboard/issues/57

This PR contains:
1. argument added to the endpoint to make a request to only display today's results: 
`integration_test_results?failed_on=today` 
    - maybe we can add this to the slack notification???
2. also add a link to the UI that takes you to ⬆️ endpoint
3. fix the issue of not being able to filter on the field `failed_on`. it was a typo! :(
4. add functionality to filter on multiple fields - this needs more work like which I will cover in next PR:
      - add an option to clear all filters - the only way right now is to refresh the page
      - also, when using multiple filters, the checked/unchecked property on filter grid is not getting set properly (only on UI side, the functionality is working just fine)
